### PR TITLE
refactor(date time formatter): use expect actual for localised date string

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -89,7 +89,7 @@ android {
     namespace = "com.boundinteractive.kmmsample"
     compileSdk = 33
     defaultConfig {
-        minSdk = 24
+        minSdk = 26
         targetSdk = 33
     }
 }

--- a/shared/src/androidMain/kotlin/com/boundinteractive/kmmsample/DateTimeHelper.kt
+++ b/shared/src/androidMain/kotlin/com/boundinteractive/kmmsample/DateTimeHelper.kt
@@ -1,0 +1,15 @@
+package com.boundinteractive.kmmsample
+
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toJavaLocalDateTime
+import kotlinx.datetime.toLocalDateTime
+import java.time.format.DateTimeFormatter
+
+actual object DateTimeHelper {
+    actual fun Instant.asFormattedDate(): String {
+        val datetime = toLocalDateTime(TimeZone.currentSystemDefault())
+        return DateTimeFormatter.ofPattern("dd-MM-yyyy hh:mm")
+            .format(datetime.toJavaLocalDateTime())
+    }
+}

--- a/shared/src/commonMain/kotlin/com/boundinteractive/kmmsample/DateTimeHelper.kt
+++ b/shared/src/commonMain/kotlin/com/boundinteractive/kmmsample/DateTimeHelper.kt
@@ -1,21 +1,7 @@
 package com.boundinteractive.kmmsample
 
 import kotlinx.datetime.Instant
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
 
-object DateTimeHelper {
-    fun String.toFormattedDate(resultTimeZone: TimeZone): String {
-        val instant = Instant.parse(this)
-        val localDateTime = instant.toLocalDateTime(resultTimeZone)
-        return localDateTime.dayOfMonth.toString().padStart(2, '0') +
-                "-" +
-                localDateTime.monthNumber.toString().padStart(2, '0') +
-                "-" +
-                localDateTime.year +
-                " " +
-                localDateTime.hour.toString().padStart(2, '0') +
-                ":" +
-                localDateTime.minute.toString().padStart(2, '0')
-    }
+expect object DateTimeHelper {
+    fun Instant.asFormattedDate(): String
 }

--- a/shared/src/commonMain/kotlin/com/boundinteractive/kmmsample/data/model/Repo.kt
+++ b/shared/src/commonMain/kotlin/com/boundinteractive/kmmsample/data/model/Repo.kt
@@ -1,7 +1,7 @@
 package com.boundinteractive.kmmsample.data.model
 
-import com.boundinteractive.kmmsample.DateTimeHelper.toFormattedDate
-import kotlinx.datetime.TimeZone
+import com.boundinteractive.kmmsample.DateTimeHelper.asFormattedDate
+import kotlinx.datetime.toInstant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -22,8 +22,8 @@ data class Repo(
     val owner: Owner,
 ) {
     val avatarUrl = owner.avatarUrl
-    private fun createdAt() = _createdAt.toFormattedDate(TimeZone.currentSystemDefault())
-    fun updatedAt() = _updatedAt.toFormattedDate(TimeZone.currentSystemDefault())
+    private fun createdAt() = _createdAt.toInstant().asFormattedDate()
+    fun updatedAt() = _updatedAt.toInstant().asFormattedDate()
 
     val accessibilityString = "A repo called $name that has $forkCount forks and " +
             "$watcherCount watchers that was last updated in ${updatedAt()}"

--- a/shared/src/iosMain/kotlin/com/boundinteractive/kmmsample/DateTimeHelper.kt
+++ b/shared/src/iosMain/kotlin/com/boundinteractive/kmmsample/DateTimeHelper.kt
@@ -1,0 +1,17 @@
+package com.boundinteractive.kmmsample
+
+import kotlinx.datetime.Instant
+import kotlinx.datetime.toNSDate
+import platform.Foundation.NSDateFormatter
+import platform.Foundation.NSLocale
+import platform.Foundation.currentLocale
+
+actual object DateTimeHelper {
+    actual fun Instant.asFormattedDate(): String {
+        val dateFormatter = NSDateFormatter().apply {
+            dateFormat = "dd-MM-yyyy hh:mm"
+            locale = NSLocale.currentLocale()
+        }
+        return dateFormatter.stringFromDate(toNSDate())
+    }
+}


### PR DESCRIPTION
Updated android api version to support DateTime. Other option could be to add desugar implementation, but as it's sample and android implementation is not getting used in app it's not done.